### PR TITLE
fix comments about wallet refill

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,7 @@ Once you have generated your Kusama address containing the string `ksma`, you ar
 
 ### Donations:
 
-If you want to support the faucet, please send KSM to this address: **EaG2CRhJWPb7qmdcJvy3LiWdh26Jreu9Dx6R1rXxPmYXoDk**
-
-The faucet's wallet will be periodically refilled from the address above.
+If you want to support the faucet, please send KSM to its wallet address: **EaG2CRhJWPb7qmdcJvy3LiWdh26Jreu9Dx6R1rXxPmYXoDk**
 
 ### Support:
 


### PR DESCRIPTION
Fixes the text about the address to support the faucet, in fact it is not the account that will refill the faucet, it is the faucet wallet itself.